### PR TITLE
Improved disable logic

### DIFF
--- a/interactive_touchscreen_button.gd
+++ b/interactive_touchscreen_button.gd
@@ -3,11 +3,11 @@ class_name InteractiveTouchscreenButton
 extends TextureButton
 
 const DefaultValues := {
-    "expand" : true,
-    "ignore_texture_size" : true,
-    "stretch_mode" : TextureButton.STRETCH_KEEP_ASPECT_CENTERED,
-    "action_mode" : TextureButton.ACTION_MODE_BUTTON_PRESS,
-    "focus_mode" : TextureButton.FOCUS_NONE,
+	"expand" : true,
+	"ignore_texture_size" : true,
+	"stretch_mode" : TextureButton.STRETCH_KEEP_ASPECT_CENTERED,
+	"action_mode" : TextureButton.ACTION_MODE_BUTTON_PRESS,
+	"focus_mode" : TextureButton.FOCUS_NONE,
 }
 
 @export_custom(PROPERTY_HINT_INPUT_NAME, "") var input_action:StringName 
@@ -18,57 +18,50 @@ var touch_index := 0
 var released := true
 
 func _init():
-    if use_default_values:
-        for k in DefaultValues.keys():
-            self.set(k, DefaultValues.get(k))
+	if use_default_values:
+		for k in DefaultValues.keys():
+			self.set(k, DefaultValues.get(k))
 
-    if touchscreen_only and not DisplayServer.is_touchscreen_available():
-        hide()
+	if touchscreen_only and not DisplayServer.is_touchscreen_available():
+		hide()
 
 
 func press():
-    var event = InputEventAction.new()
-    event.action = input_action
-    event.pressed = true
-    Input.parse_input_event(event)
-    released = false
+	var event = InputEventAction.new()
+	event.action = input_action
+	event.pressed = true
+	Input.parse_input_event(event)
+	released = false
 
 
 func release():
-    var event = InputEventAction.new()
-    event.action = input_action
-    event.pressed = false
-    Input.parse_input_event(event)
-    released = true
+	var event = InputEventAction.new()
+	event.action = input_action
+	event.pressed = false
+	Input.parse_input_event(event)
+	released = true
 
 
 func is_in(pos:Vector2) -> bool:
-    if int(pos.x) in range(global_position.x, global_position.x + size.x):
-        if int(pos.y) in range(global_position.y, global_position.y + size.y):
-            return true 
-    return false
+	if int(pos.x) in range(global_position.x, global_position.x + size.x):
+		if int(pos.y) in range(global_position.y, global_position.y + size.y):
+			return true 
+	return false
 
 
 func _input(event):
-    if event is InputEventScreenTouch:
-        # 1. ALWAYS process the release event to reset internal state,
-        # even if the button is currently disabled.
-        if not event.pressed:
-            if touch_index == event.index:
-                release()
-            return
-
-        # 2. If the button is disabled, we ignore the press event.
-        # Because we handled 'not event.pressed' above, the button 
-        # will still reset properly when the finger is lifted.
-        if disabled:
-            return
-
-        # 3. Handle the press logic
-        if is_in(event.position):
-            if released:
-                touch_index = event.index
-                press()
-            else:
-                # Handle multi-touch interference
-                release()
+	if event is InputEventScreenTouch:
+		if not event.pressed:
+			if touch_index == event.index:
+				release()
+			return
+			
+		if disabled:
+			return
+			
+		if is_in(event.position):
+			if released:
+				touch_index = event.index
+				press()
+			else:
+				release()

--- a/interactive_touchscreen_button.gd
+++ b/interactive_touchscreen_button.gd
@@ -3,11 +3,11 @@ class_name InteractiveTouchscreenButton
 extends TextureButton
 
 const DefaultValues := {
-	"expand" : true,
-	"ignore_texture_size" : true,
-	"stretch_mode" : TextureButton.STRETCH_KEEP_ASPECT_CENTERED,
-	"action_mode" : TextureButton.ACTION_MODE_BUTTON_PRESS,
-	"focus_mode" : TextureButton.FOCUS_NONE,
+    "expand" : true,
+    "ignore_texture_size" : true,
+    "stretch_mode" : TextureButton.STRETCH_KEEP_ASPECT_CENTERED,
+    "action_mode" : TextureButton.ACTION_MODE_BUTTON_PRESS,
+    "focus_mode" : TextureButton.FOCUS_NONE,
 }
 
 @export_custom(PROPERTY_HINT_INPUT_NAME, "") var input_action:StringName 
@@ -18,47 +18,57 @@ var touch_index := 0
 var released := true
 
 func _init():
-	if use_default_values :
-		for k in DefaultValues.keys() :
-			self.set(k, DefaultValues.get(k))
-	
-	if touchscreen_only and not DisplayServer.is_touchscreen_available() :
-		hide()
+    if use_default_values:
+        for k in DefaultValues.keys():
+            self.set(k, DefaultValues.get(k))
+
+    if touchscreen_only and not DisplayServer.is_touchscreen_available():
+        hide()
 
 
 func press():
-	var event = InputEventAction.new()
-	event.action = input_action
-	event.pressed = true
-	Input.parse_input_event(event)
-	released = false
+    var event = InputEventAction.new()
+    event.action = input_action
+    event.pressed = true
+    Input.parse_input_event(event)
+    released = false
 
 
 func release():
-	var event = InputEventAction.new()
-	event.action = input_action
-	event.pressed = false
-	Input.parse_input_event(event)
-	released = true
+    var event = InputEventAction.new()
+    event.action = input_action
+    event.pressed = false
+    Input.parse_input_event(event)
+    released = true
 
 
 func is_in(pos:Vector2) -> bool:
-	if int(pos.x) in range(global_position.x, global_position.x+size.x) :
-		if int(pos.y) in range(global_position.y, global_position.y+size.y) :
-			return true 
-	return false
+    if int(pos.x) in range(global_position.x, global_position.x + size.x):
+        if int(pos.y) in range(global_position.y, global_position.y + size.y):
+            return true 
+    return false
 
 
 func _input(event):
-	if disabled:
-		return
-	if event is InputEventScreenTouch :
-		if event.pressed and is_in(event.position) :
-			if released :
-				touch_index = event.index
-			if touch_index == event.index :
-				press()
-			else :
-				release()
-		if touch_index == event.index and not event.pressed :
-			release()
+    if event is InputEventScreenTouch:
+        # 1. ALWAYS process the release event to reset internal state,
+        # even if the button is currently disabled.
+        if not event.pressed:
+            if touch_index == event.index:
+                release()
+            return
+
+        # 2. If the button is disabled, we ignore the press event.
+        # Because we handled 'not event.pressed' above, the button 
+        # will still reset properly when the finger is lifted.
+        if disabled:
+            return
+
+        # 3. Handle the press logic
+        if is_in(event.position):
+            if released:
+                touch_index = event.index
+                press()
+            else:
+                # Handle multi-touch interference
+                release()

--- a/interactive_touchscreen_button.gd
+++ b/interactive_touchscreen_button.gd
@@ -50,6 +50,8 @@ func is_in(pos:Vector2) -> bool:
 
 
 func _input(event):
+	if disabled:
+		return
 	if event is InputEventScreenTouch :
 		if event.pressed and is_in(event.position) :
 			if released :


### PR DESCRIPTION
## Improved func _input(event) to make the disable function work. Before this, disabling a button only disabled its texture but the button itself was clickable and it was taking input.

The changes:
```
func _input(event):
	if event is InputEventScreenTouch:
		if not event.pressed:
			if touch_index == event.index:
				release()
			return
			
		if disabled:
			return
			
		if is_in(event.position):
			if released:
				touch_index = event.index
				press()
			else:
				release()
```
### Before:
<img width="1396" height="720" alt=" before" src="https://github.com/user-attachments/assets/5c66abd0-3371-4ce3-a199-79f53113e71c" />

### After:
<img width="1396" height="720" alt="after" src="https://github.com/user-attachments/assets/fc16dbdf-c3d5-40a8-acd8-d63595aae327" />
